### PR TITLE
treat reply message properly

### DIFF
--- a/src/main/kotlin/io/github/yusaka39/easySlackbot/slack/impl/SimpleSlackApiSlack.kt
+++ b/src/main/kotlin/io/github/yusaka39/easySlackbot/slack/impl/SimpleSlackApiSlack.kt
@@ -34,7 +34,7 @@ class SimpleSlackApiSlack(slackToken: String) : Slack {
                     this@SimpleSlackApiSlack.logger.info("Received DM.")
                     this@SimpleSlackApiSlack.onReceiveDirectMessage(message, this@SimpleSlackApiSlack)
                 }
-                slackMessagePosted.messageSubType == SlackMessagePosted.MessageSubType.MESSAGE_REPLIED -> {
+                slackMessagePosted.messageContent.contains("<@${this@SimpleSlackApiSlack.myId}>") -> {
                     this@SimpleSlackApiSlack.logger.info("Received a reply.")
                     this@SimpleSlackApiSlack.onReceiveReply(message, this@SimpleSlackApiSlack)
                 }


### PR DESCRIPTION
`MESSAGE_REPLIED` indicates reply events to thread
https://api.slack.com/events/message/message_replied

and `simple-slack-api` we use as a slack client does not support it (ignore as UNKNOWN)
https://github.com/Ullink/simple-slack-api/blob/d3fe7de81118a72dcf9254b78e96252b5ae64cd1/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java#L177

so we have to confirm whether message is reply or non-reply by checking message content